### PR TITLE
Use find_by(name: ...) instead of find_by_name

### DIFF
--- a/lib/qyu/models/job.rb
+++ b/lib/qyu/models/job.rb
@@ -145,7 +145,7 @@ module Qyu
     end
 
     def self.persist(workflow, payload)
-      workflow = Qyu::Workflow.find_by_name(workflow) if workflow.is_a?(String)
+      workflow = Qyu::Workflow.find_by(name: workflow) if workflow.is_a?(String)
       Qyu.store.persist_job(workflow, payload)
     end
 


### PR DESCRIPTION
find_by_name is a private method